### PR TITLE
Removing constructor double write

### DIFF
--- a/src/TgSharp.TL/TLObject.cs
+++ b/src/TgSharp.TL/TLObject.cs
@@ -27,16 +27,11 @@ namespace TgSharp.TL
             using (MemoryStream m = new MemoryStream())
             using (BinaryWriter bw = new BinaryWriter(m))
             {
-                Serialize(bw);
+                SerializeBody(bw);
                 bw.Close();
                 m.Close();
                 return m.ToArray();
             }
-        }
-        public void Serialize(BinaryWriter writer)
-        {
-            writer.Write(Constructor);
-            SerializeBody(writer);
         }
         public void Deserialize(BinaryReader reader)
         {


### PR DESCRIPTION
In "TLObject.Serialize() -> Serialize(BinaryWriter br) -> SerializeBody"  code path, constructor get written two times instead of once, which since this code path is currently unused and it's only provided for completeness, It's undetectable while testing.