### PR TITLE
Run Tests in CI (Windows OS only for now)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,4 +47,23 @@ jobs:
       uses: microsoft/setup-msbuild@v1
 
     - name: Build Project
-      run: MSBuild src/TgSharp.sln
+      run: MSBuild src/TgSharp.sln && MSBuild -t:Clean src/TgSharp.sln
+
+    - name: Prepare test suite assets
+      run: |
+        echo "$APP_CONFIG_IN_TESTS" > app.config
+        echo "$SESSION_DAT_IN_TESTS" > encodedSession.dat
+      shell: bash
+      env:
+        APP_CONFIG_IN_TESTS: ${{secrets.APP_CONFIG_IN_TESTS}}
+        SESSION_DAT_IN_TESTS: ${{secrets.SESSION_DAT_IN_TESTS}}
+
+    - name: Run Tests
+      run: |
+        MSBuild -p:Configuration=Debug -p:CI=true src/TgSharp.sln
+
+        certutil -decode encodedSession.dat src/TgSharp.Tests.NUnit/bin/Debug/session.dat
+        cp app.config src/TgSharp.Tests.NUnit/bin/Debug/TgSharp.Tests.NUnit.dll.config
+
+        ./Nuget.exe install NUnit.Runners -Version 3.11.1 -OutputDirectory packages
+        ./packages/NUnit.ConsoleRunner.3.11.1/tools/nunit3-console.exe src/TgSharp.Tests.NUnit/bin/Debug/TgSharp.Tests.NUnit.dll

--- a/src/TgSharp.Core/Session.cs
+++ b/src/TgSharp.Core/Session.cs
@@ -76,11 +76,23 @@ namespace TgSharp.Core
         private const string defaultConnectionAddress = "149.154.175.100";//"149.154.167.50";
         private const int defaultConnectionPort = 443;
 
+        public int Sequence { get; set; }
+#if CI
+            // see the same CI-wrapped assignment in .FromBytes(), but this one will become useful
+            // when we generate a new session.dat for CI again
+            = CurrentTime ();
+
+        // this is similar to the unixTime but rooted on the worst year of humanity instead of 1970
+        private static int CurrentTime ()
+        {
+            return (int)DateTime.UtcNow.Subtract (new DateTime (2020, 1, 1)).TotalSeconds;
+        }
+#endif
+
         public string SessionUserId { get; set; }
         internal DataCenter DataCenter { get; set; }
         public AuthKey AuthKey { get; set; }
         public ulong Id { get; set; }
-        public int Sequence { get; set; }
         public ulong Salt { get; set; }
         public int TimeOffset { get; set; }
         public long LastMessageId { get; set; }
@@ -133,6 +145,13 @@ namespace TgSharp.Core
             {
                 var id = reader.ReadUInt64();
                 var sequence = reader.ReadInt32();
+
+// we do this in CI when running tests so that the they can always use a
+// higher sequence than previous run
+#if CI
+                sequence = CurrentTime();
+#endif
+
                 var salt = reader.ReadUInt64();
                 var lastMessageId = reader.ReadInt64();
                 var timeOffset = reader.ReadInt32();

--- a/src/TgSharp.Core/TgSharp.Core.csproj
+++ b/src/TgSharp.Core/TgSharp.Core.csproj
@@ -30,6 +30,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(CI)'=='true'">
+    <DefineConstants>$(DefineConstants);CI</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/TgSharp.Tests.NUnit/Test.cs
+++ b/src/TgSharp.Tests.NUnit/Test.cs
@@ -16,6 +16,7 @@ namespace TgSharp.Tests
         }
 
         [Test]
+        [Ignore("Only run again when you want a new CodeToAuthenticate value in your app.config")]
         public async override Task AuthUser()
         {
             await base.AuthUser();
@@ -28,42 +29,49 @@ namespace TgSharp.Tests
         }
 
         [Test]
+        [Ignore("Untested in CI")]
         public override async Task SendMessageToChannelTest()
         {
             await base.SendMessageToChannelTest();
         }
 
         [Test]
+        [Ignore("Untested in CI")]
         public override async Task SendPhotoToContactTest()
         {
             await base.SendPhotoToContactTest();
         }
 
         [Test]
+        [Ignore("Untested in CI")]
         public override async Task SendBigFileToContactTest()
         {
             await base.SendBigFileToContactTest();
         }
 
         [Test]
+        [Ignore("Untested in CI")]
         public override async Task DownloadFileFromContactTest()
         {
             await base.DownloadFileFromContactTest();
         }
 
         [Test]
+        [Ignore("Untested in CI")]
         public override async Task DownloadFileFromWrongLocationTest()
         {
             await base.DownloadFileFromWrongLocationTest();
         }
 
         [Test]
+        [Ignore("Untested in CI")]
         public override async Task SignUpNewUser()
         {
             await base.SignUpNewUser();
         }
 
         [Test]
+        [Ignore("Untested in CI")]
         public override async Task SendMessageByUserNameTest()
         {
             await base.SendMessageByUserNameTest();

--- a/src/TgSharp.Tests/app.config
+++ b/src/TgSharp.Tests/app.config
@@ -1,13 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
+    <!-- these values are used in CI so far: -->
     <add key="ApiHash" value="" />
     <add key="ApiId" value="" />
     <add key="NumberToAuthenticate" value="" />
     <add key="CodeToAuthenticate" value="" />
+    <add key="NumberToSendMessage" value="" />
+    <!---->
+
     <add key="PasswordToAuthenticate" value=""/>
     <add key="NotRegisteredNumberToSignUp" value=""/>
-    <add key="NumberToSendMessage" value=""/>
     <add key="UserNameToSendMessage" value=""/>
     <add key="NumberToGetUserFull" value=""/>
     <add key="NumberToAddToChat" value=""/>


### PR DESCRIPTION
The reason for such a hack when runing in CI is because we
need to make sure we're using higher sequence numbers than
any previous times (and even previous runs of the test suite).

And we run 1 test only for now, later we will enable more.

Other notes:

The trick to extract secrets to files was taken from:
https://stackoverflow.com/a/59482124/544947

The binary-to-text encoding/decoding was taken from:
https://stackoverflow.com/a/42725926/544947

The way to add defines to DefineConstants for MSBuild:
https://stackoverflow.com/a/5053070/544947