### PR TITLE
Tests: fix & reenable SendPhotoToContactTest

### DIFF
--- a/src/TgSharp.Core/TelegramClient.cs
+++ b/src/TgSharp.Core/TelegramClient.cs
@@ -336,13 +336,18 @@ namespace TgSharp.Core
                 .ConfigureAwait(false);
         }
 
-        public async Task<TLAbsUpdates> SendUploadedPhoto(TLAbsInputPeer peer, TLAbsInputFile file, CancellationToken token = default(CancellationToken))
+        public async Task<TLAbsUpdates> SendUploadedPhoto(TLAbsInputPeer peer, TLAbsInputFile file, string message, CancellationToken token = default(CancellationToken))
         {
+            if (String.IsNullOrEmpty(message)) {
+                throw new ArgumentNullException (nameof (message));
+            }
+
             return await SendAuthenticatedRequestAsync<TLAbsUpdates>(new TLRequestSendMedia()
             {
                 RandomId = Helpers.GenerateRandomLong(),
                 Background = false,
                 ClearDraft = false,
+                Message = message,
                 Media = new TLInputMediaUploadedPhoto() { File = file },
                 Peer = peer
             }, token)

--- a/src/TgSharp.Tests.NUnit/Test.cs
+++ b/src/TgSharp.Tests.NUnit/Test.cs
@@ -36,7 +36,6 @@ namespace TgSharp.Tests
         }
 
         [Test]
-        [Ignore("Untested in CI")]
         public override async Task SendPhotoToContactTest()
         {
             await base.SendPhotoToContactTest();

--- a/src/TgSharp.Tests/TgSharpTests.cs
+++ b/src/TgSharp.Tests/TgSharpTests.cs
@@ -206,7 +206,7 @@ namespace TgSharp.Tests
                 .FirstOrDefault(x => x.Phone == NumberToSendMessage);
 
             var fileResult = (TLInputFile)await client.UploadFile("cat.jpg", new StreamReader("data/cat.jpg"));
-            await client.SendUploadedPhoto(new TLInputPeerUser() { UserId = user.Id }, fileResult);
+            await client.SendUploadedPhoto(new TLInputPeerUser() { UserId = user.Id }, fileResult, "cat");
         }
 
         public virtual async Task SendBigFileToContactTest()


### PR DESCRIPTION
It got broken in one [1] of the LayerUpdate PR [2]
commits because TLInputMediaUploadedPhoto's [3]
Caption property was dropped, but somehow the
replacement of it is now TLRequestSendMedia's [4]
Message property.

[1] https://github.com/nblockchain/TgSharp/commit/07c4812e993d6a57b3636cec47437d6f08ba7c0f
[2] https://github.com/nblockchain/TgSharp/pull/13
[3] https://github.com/nblockchain/TgSharp/commit/07c4812e993d6a57b3636cec47437d6f08ba7c0f#diff-8fc2b6f90844589a5a85c31971236c6a
[4] https://github.com/nblockchain/TgSharp/commit/07c4812e993d6a57b3636cec47437d6f08ba7c0f#diff-6579e69beaef1ce3efce20d9f9a087ea