### PR TITLE
 Core: don't load seqNo and sessionId on start

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Run Tests
       run: |
-        MSBuild -p:Configuration=Debug -p:CI=true src/TgSharp.sln
+        MSBuild -p:Configuration=Debug src/TgSharp.sln
 
         certutil -decode encodedSession.dat src/TgSharp.Tests.NUnit/bin/Debug/session.dat
         cp app.config src/TgSharp.Tests.NUnit/bin/Debug/TgSharp.Tests.NUnit.dll.config

--- a/src/TgSharp.Core/FileSessionStore.cs
+++ b/src/TgSharp.Core/FileSessionStore.cs
@@ -54,13 +54,6 @@ namespace TgSharp.Core
             using (var reader = new BinaryReader (stream)) {
                 var id = reader.ReadUInt64 ();
                 var sequence = reader.ReadInt32 ();
-
-                // we do this in CI when running tests so that the they can always use a
-                // higher sequence than previous run
-#if CI
-                sequence = Session.CurrentTime();
-#endif
-
                 var salt = reader.ReadUInt64 ();
                 var lastMessageId = reader.ReadInt64 ();
                 var timeOffset = reader.ReadInt32 ();

--- a/src/TgSharp.Core/Session.cs
+++ b/src/TgSharp.Core/Session.cs
@@ -60,18 +60,6 @@ namespace TgSharp.Core
         internal object Lock = new object ();
 
         public int Sequence { get; set; }
-#if CI
-            // see the same CI-wrapped assignment in .FromBytes(), but this one will become useful
-            // when we generate a new session.dat for CI again
-            = CurrentTime ();
-
-        // this is similar to the unixTime but rooted on the worst year of humanity instead of 1970
-        internal static int CurrentTime ()
-        {
-            return (int)DateTime.UtcNow.Subtract (new DateTime (2020, 1, 1)).TotalSeconds;
-        }
-#endif
-
         public string SessionUserId { get; set; }
         internal DataCenter DataCenter { get; set; }
         public AuthKey AuthKey { get; set; }

--- a/src/TgSharp.Core/Session.cs
+++ b/src/TgSharp.Core/Session.cs
@@ -4,6 +4,7 @@ using System.IO;
 using TgSharp.TL;
 using TgSharp.Core.MTProto;
 using TgSharp.Core.MTProto.Crypto;
+using System.Security.Cryptography;
 
 namespace TgSharp.Core
 {
@@ -39,6 +40,10 @@ namespace TgSharp.Core
                     DataCenter = defaultDataCenter,
                 };
             }
+            session.Sequence = 0;
+            byte[] randomSessionId = new byte[8];
+            RandomNumberGenerator.Create().GetNonZeroBytes(randomSessionId);
+            session.Id = BitConverter.ToUInt64(randomSessionId, 0);
             return session;
         }
 

--- a/src/TgSharp.Core/TgSharp.Core.csproj
+++ b/src/TgSharp.Core/TgSharp.Core.csproj
@@ -30,9 +30,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(CI)'=='true'">
-    <DefineConstants>$(DefineConstants);CI</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
This PR randomizes SeqNo and SessionID on start this prevents some errors (code=32) but It doesn't remove these fields from Session class to keep compatibility with older session files also It removes a previously used hack to make CI work with outdated SessionId and Seqno because it's no longer needed after this change.