### PR TITLE
Tests: load NumberToSendMessage in init process

### DIFF
--- a/src/TgSharp.Tests/TgSharpTests.cs
+++ b/src/TgSharp.Tests/TgSharpTests.cs
@@ -118,6 +118,16 @@ namespace TgSharp.Tests
             NumberToAddToChat = ConfigurationManager.AppSettings[nameof(NumberToAddToChat)];
             if (string.IsNullOrEmpty(NumberToAddToChat))
                 Debug.WriteLine(appConfigMsgWarning, nameof(NumberToAddToChat));
+
+            NumberToSendMessage = ConfigurationManager.AppSettings[nameof(NumberToSendMessage)];
+            if (string.IsNullOrWhiteSpace(NumberToSendMessage))
+                Debug.WriteLine(appConfigMsgWarning, nameof(NumberToSendMessage));
+            else
+                NumberToSendMessage =
+                    NumberToSendMessage.StartsWith("+") ?
+                    NumberToSendMessage.Substring(1, NumberToSendMessage.Length - 1) :
+                    NumberToSendMessage;
+
         }
 
         public virtual async Task AuthUser()
@@ -150,15 +160,6 @@ namespace TgSharp.Tests
 
         public virtual async Task SendMessageTest()
         {
-            NumberToSendMessage = ConfigurationManager.AppSettings[nameof(NumberToSendMessage)];
-            if (string.IsNullOrWhiteSpace(NumberToSendMessage))
-                throw new Exception($"Please fill the '{nameof(NumberToSendMessage)}' setting in app.config file first");
-
-            // this is because the contacts in the address come without the "+" prefix
-            var normalizedNumber = NumberToSendMessage.StartsWith("+") ?
-                NumberToSendMessage.Substring(1, NumberToSendMessage.Length - 1) :
-                NumberToSendMessage;
-
             var client = NewClient();
 
             await client.ConnectAsync();
@@ -167,7 +168,7 @@ namespace TgSharp.Tests
 
             var user = result.Users
                 .OfType<TLUser>()
-                .FirstOrDefault(x => x.Phone == normalizedNumber);
+                .FirstOrDefault(x => x.Phone == NumberToSendMessage);
 
             if (user == null)
             {


### PR DESCRIPTION
738a849 moves loading of "NumberToSendMessage" property
to SendMessage test even though there are 3 other tests
that use that variable thereby breaking all 3 tests
because of NumberToSendMessage being null.

This commit moves the load process back to init phase so
all 4 tests can use NumberToSendMessage.
