### PR TITLE
Make `TelegramClient.SendAuthenticatedRequestAsync` public

### DIFF
--- a/src/TgSharp.Core/TelegramClient.cs
+++ b/src/TgSharp.Core/TelegramClient.cs
@@ -244,7 +244,7 @@ namespace TgSharp.Core
             return (T)result;
         }
 
-        internal async Task<T> SendAuthenticatedRequestAsync<T>(TLMethod methodToExecute, CancellationToken token = default(CancellationToken))
+        public async Task<T> SendAuthenticatedRequestAsync<T>(TLMethod methodToExecute, CancellationToken token = default(CancellationToken))
         {
             if (!IsUserAuthorized())
                 throw new InvalidOperationException("Authorize user first!");


### PR DESCRIPTION
Useful to send authenticated custom requests with methods that aren't supported by TgSharp's `TelegramClient` by default